### PR TITLE
Adding support for grabbing content from HTTPS sites.

### DIFF
--- a/admin/templates/head.html.php
+++ b/admin/templates/head.html.php
@@ -17,7 +17,7 @@
 	<a class="logout" href="?logout">Logout</a>
 
 	Bookmarklet:
-	<a class="bookmarklet" title="Post Bookmarklet" href="javascript:void((function(){var%20e=document.createElement('script');e.type='text/javascript';e.src='<?php echo ASAPH_POST_JS; ?>';document.body.appendChild(e)})());">Asaph</a>
+	<a class="bookmarklet" title="Post Bookmarklet" href="javascript:void((function(){var%20e=document.createElement('script');e.type='text/javascript';e.src='<?php echo ASAPH_BOOKMARK_POST_JS; ?>';document.body.appendChild(e)})());">Asaph</a>
 </div>
 
 <div id="content">

--- a/lib/asaph_config.class.php
+++ b/lib/asaph_config.class.php
@@ -48,9 +48,12 @@ class Asaph_Config {
 define( 'ASAPH_TABLE_POSTS',	Asaph_Config::$db['prefix'].'posts' );
 define( 'ASAPH_TABLE_USERS',	Asaph_Config::$db['prefix'].'users' );
 
-define( 'ASAPH_BASE_URL',		'http://'.Asaph_Config::$domain.Asaph_Config::$absolutePath );
+$protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443 || $_SERVER['HTTP_X_FORWARDED_PORT'] == 443) ? "https://" : "http://";
+//ORG define( 'ASAPH_BASE_URL',		'http://'.Asaph_Config::$domain.Asaph_Config::$absolutePath );
+define( 'ASAPH_BASE_URL',		$protocol.Asaph_Config::$domain.Asaph_Config::$absolutePath );
 define( 'ASAPH_POST_PHP',		ASAPH_BASE_URL.'admin/post.php' );
 define( 'ASAPH_POST_JS',		ASAPH_BASE_URL.'admin/post.js.php' );
+define( 'ASAPH_BOOKMARK_POST_JS',	'window.location.protocol%2B//'.Asaph_Config::$domain.Asaph_Config::$absolutePath.'admin/post.js.php' );
 define( 'ASAPH_POST_CSS',		ASAPH_BASE_URL.'admin/templates/post.css' );
 
 if( function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() ) {


### PR DESCRIPTION
IMPORTANT: your Asaph site needs to be provisioned for both HTTP and HTTPS. HTTP source sites use your HTTP Asaph site, HTTPS source sites automatically use your HTTPS Asaph site.

The bookmarklet will call your Asaph site in the SAME protocol that the source site uses. The Asaph script injects code into the source page using the appropriate protocol.
For example, 500px.com always uses HTTPS and the Asaph bookmarklet will call your Asaph site using HTTPS. Site tumblr.com is using HTTP and the Asaph bookmarklet will call your Asaph using HTTP.