### PR TITLE
Fixing wrongly placed single-quote for the bookmarklet.

### DIFF
--- a/admin/templates/head.html.php
+++ b/admin/templates/head.html.php
@@ -17,7 +17,7 @@
 	<a class="logout" href="?logout">Logout</a>
 
 	Bookmarklet:
-	<a class="bookmarklet" title="Post Bookmarklet" href="javascript:void((function(){var%20e=document.createElement('script');e.type='text/javascript';e.src='<?php echo ASAPH_BOOKMARK_POST_JS; ?>';document.body.appendChild(e)})());">Asaph</a>
+	<a class="bookmarklet" title="Post Bookmarklet" href="javascript:void((function(){var%20e=document.createElement('script');e.type='text/javascript';e.src=<?php echo ASAPH_BOOKMARK_POST_JS; ?>';document.body.appendChild(e)})());">Asaph</a>
 </div>
 
 <div id="content">

--- a/lib/asaph_config.class.php
+++ b/lib/asaph_config.class.php
@@ -53,7 +53,7 @@ $protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERV
 define( 'ASAPH_BASE_URL',		$protocol.Asaph_Config::$domain.Asaph_Config::$absolutePath );
 define( 'ASAPH_POST_PHP',		ASAPH_BASE_URL.'admin/post.php' );
 define( 'ASAPH_POST_JS',		ASAPH_BASE_URL.'admin/post.js.php' );
-define( 'ASAPH_BOOKMARK_POST_JS',	'window.location.protocol%2B//'.Asaph_Config::$domain.Asaph_Config::$absolutePath.'admin/post.js.php' );
+define( 'ASAPH_BOOKMARK_POST_JS',	'window.location.protocol%2B\'//'.Asaph_Config::$domain.Asaph_Config::$absolutePath.'admin/post.js.php' );
 define( 'ASAPH_POST_CSS',		ASAPH_BASE_URL.'admin/templates/post.css' );
 
 if( function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() ) {


### PR DESCRIPTION
Hyman reported a problem with the bookmarklet. It seems a single quote was placed at the wrong place. This should fix it.
